### PR TITLE
Refine franchise mutation helpers

### DIFF
--- a/src/main/java/com/example/franchises/domain/usecase/AddBranchUseCase.java
+++ b/src/main/java/com/example/franchises/domain/usecase/AddBranchUseCase.java
@@ -6,6 +6,7 @@ import com.example.franchises.domain.model.Branch;
 import com.example.franchises.domain.model.Franchise;
 import com.example.franchises.infrastructure.repository.SpringDataFranchiseRepository;
 import reactor.core.publisher.Mono;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.UUID;
 
@@ -21,5 +22,9 @@ public class AddBranchUseCase {
         return repo.save(updated).thenReturn(newBranch);
       });
   }
-  private static List<Branch> concat(List<Branch> list, Branch b) { return new java.util.ArrayList<>(list) {{ add(b); }}; }
+  private static List<Branch> concat(List<Branch> list, Branch branch) {
+    List<Branch> updatedBranches = new ArrayList<>(list);
+    updatedBranches.add(branch);
+    return List.copyOf(updatedBranches);
+  }
 }

--- a/src/main/java/com/example/franchises/domain/usecase/AddProductUseCase.java
+++ b/src/main/java/com/example/franchises/domain/usecase/AddProductUseCase.java
@@ -22,10 +22,14 @@ public class AddProductUseCase {
         return repo.save(updated).thenReturn(newProduct);
       });
   }
-  private static java.util.List<Product> concat(java.util.List<Product> list, Product p){ return new java.util.ArrayList<>(list) {{ add(p); }}; }
+  private static java.util.List<Product> concat(java.util.List<Product> list, Product product){
+    java.util.List<Product> updatedProducts = new java.util.ArrayList<>(list);
+    updatedProducts.add(product);
+    return java.util.List.copyOf(updatedProducts);
+  }
   private static java.util.List<Branch> replaceBranch(java.util.List<Branch> list, Branch updated){
     java.util.List<Branch> res = new java.util.ArrayList<>(list);
     for (int i=0;i<res.size();i++) if (res.get(i).id().equals(updated.id())) { res.set(i, updated); break; }
-    return res;
+    return java.util.List.copyOf(res);
   }
 }


### PR DESCRIPTION
## Summary
- replace double-brace list initializers in franchise mutation use cases with clearer array list usage
- return defensive copies of mutable lists before passing them to domain records

## Testing
- ⚠️ `./gradlew test` *(fails: Unable to tunnel through proxy. Proxy returns "HTTP/1.1 403 Forbidden")*

------
https://chatgpt.com/codex/tasks/task_e_68d565cc0aac8320b2f06da4c215b61c